### PR TITLE
Fix require example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ In the `build.boot` of your project:
 (load-data-readers!)
 
 (require
- '[com.flyingmachine.datomic-booties.tasks :refer all])
+ '[com.flyingmachine.datomic-booties.tasks :refer :all])
 ```
 
 Then, from the terminal, run things like

--- a/README.md
+++ b/README.md
@@ -87,5 +87,5 @@ In the `build.boot` of your project:
 Then, from the terminal, run things like
 
 ```
-$ boot bootstrap-db :uri "datomic:free://localhost:4334/datomic-booties-dev"
+$ boot bootstrap-db -u "datomic:free://localhost:4334/datomic-booties-dev"
 ```


### PR DESCRIPTION
- `:all` needs to be a keyword, not a symbol
- The terminal example needs to use the CLI argument style
